### PR TITLE
Example using Flamingock CE BOM

### DIFF
--- a/s3/.sdkmanrc
+++ b/s3/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 #java=17.0.3-tem
-java=8.0.382-amzn
+java=8.0.422-amzn

--- a/s3/build.gradle.kts
+++ b/s3/build.gradle.kts
@@ -3,14 +3,6 @@ plugins {
     application
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
-}
-
 repositories {
     mavenLocal()
     mavenCentral() // Fallback for other dependencies
@@ -26,9 +18,20 @@ dependencies {
     // Import the flamingock BOM
     implementation(platform("io.flamingock:flamingock-ce-bom:$flamingockVersion"))
 
+    // Dependencies managed by the BOM
+    implementation("io.flamingock:flamingock-core")
+    implementation("io.flamingock:flamingock-core-api")
+    implementation("io.flamingock:flamingock-ce-dynamodb")
+    implementation("io.flamingock:flamingock-ce-commons")
+
     // AWS SDK dependencies with explicit versions
-    implementation("software.amazon.awssdk:dynamodb-enhanced:$awsSdkVersion")
-    implementation("software.amazon.awssdk:url-connection-client:$awsSdkVersion")
+    implementation(platform("software.amazon.awssdk:bom:$awsSdkVersion"))
+    implementation("software.amazon.awssdk:s3")                        // Add S3 client
+    implementation("software.amazon.awssdk:dynamodb")                  // Base DynamoDB client
+    implementation("software.amazon.awssdk:dynamodb-enhanced")         // Enhanced DynamoDB client
+    implementation("software.amazon.awssdk:url-connection-client")     // HTTP client implementation
+
+    annotationProcessor("io.flamingock:flamingock-core:$flamingockVersion")
 
     // Other dependencies
     implementation("org.slf4j:slf4j-api:2.0.6")
@@ -40,20 +43,9 @@ dependencies {
 }
 
 application {
-    mainClass = "io.flamingock.examples.dynamodb.standalone.CommunityStandaloneDynamoDBApp"
+    mainClass = "io.flamingock.examples.s3.S3FlamingockExample"
 }
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
-}
-
-// Optional task to verify dependency versions
-tasks.register("printDependencyVersions") {
-    doLast {
-        configurations.compileClasspath.get().resolvedConfiguration.lenientConfiguration.allModuleDependencies.forEach {
-            if (it.moduleGroup == "io.flamingock") {
-                println("${it.moduleGroup}:${it.moduleName}:${it.moduleVersion}")
-            }
-        }
-    }
 }

--- a/s3/src/main/java/io/flamingock/examples/s3/S3FlamingockExample.java
+++ b/s3/src/main/java/io/flamingock/examples/s3/S3FlamingockExample.java
@@ -16,11 +16,9 @@
 
 package io.flamingock.examples.s3;
 
-import io.flamingock.core.configurator.standalone.FlamingockStandalone;
-import io.flamingock.core.pipeline.Stage;
 import io.flamingock.examples.s3.util.DynamoDBUtil;
 import io.flamingock.examples.s3.util.S3Util;
-import io.flamingock.oss.driver.dynamodb.driver.DynamoDBDriver;
+import io.flamingock.community.Flamingock;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -33,11 +31,8 @@ public class S3FlamingockExample {
     }
 
     public void run(S3Client s3Client, DynamoDbClient dynamoDbClient) {
-
-        FlamingockStandalone.local()
-                .setDriver(new DynamoDBDriver(dynamoDbClient))
-                .addStage(new Stage("stage-name")
-                        .addCodePackage("io.flamingock.examples.s3.changes"))
+        Flamingock.builder()
+                .addDependency(dynamoDbClient)
                 .addDependency(s3Client)
                 .build()
                 .run();

--- a/s3/src/main/resources/flamingock/pipeline.yaml
+++ b/s3/src/main/resources/flamingock/pipeline.yaml
@@ -1,0 +1,6 @@
+pipeline:
+  stages:
+    - name: s3-migration
+      description: s3 example
+      sourcesPackage: io.flamingock.examples.s3.changes
+


### PR DESCRIPTION
### **_This PR cannot be merged, the purpose is to show an example using the BOM in mavenLocal, once it is validated and is in mavenCentral it can be merged as updated example._**

The purpose of this example is using mavenLocal

The first step is to publish the BOM in mavenLocal 

```
 ./gradlew clean build 
 ./gradlew publishToMavenLocal 
```

To run the example:

in s3 folder

```
./gradlew build --info --refresh-dependencies
./gradlew clean build 
./gradlew run 
```

Annotation processor output:

```
Note:    [Flamingock] Starting Flamingock annotation processor initialization.
warning: [Flamingock] 'resources' parameter NOT passed. Using default 'src/main/resources'
warning: [Flamingock] 'sources' parameter NOT passed. Searching in: '[src/main/java, src/main/kotlin, src/main/scala, src/main/groovy]'
Note:    [Flamingock] Reading flamingock pipeline from file: 'src/main/resources/flamingock/pipeline.yaml'
Note:    [Flamingock] Initialization completed. Processed templated-based changes.
Note:    [Flamingock] Searching for code-based changes (Java classes annotated with @ChangeUnit annotation)
Note:    [Flamingock] Reading flamingock pipeline from file: 'src/main/resources/flamingock/pipeline.yaml'
Note:    [Flamingock] Finished processing annotated classes and generating metadata.
Note:    [Flamingock] Final processing round detected - skipping execution.
```


